### PR TITLE
Fix for 'Resource busy' error

### DIFF
--- a/AutoNBI.py
+++ b/AutoNBI.py
@@ -888,7 +888,7 @@ class processNBI(object):
                 if os.path.exists(ldfullpath):
                     os.unlink(ldfullpath)
         # Handle any custom content to be added, customfolder has a value
-        if self.customfolder is not None:
+        if self.customfolder:
             print("-------------------------------------------------------------------------")
             print "Modifying NetBoot volume at %s" % nbimount
 


### PR DESCRIPTION
Without including the `--folder` option, the script would consistently fail showing the following:
```
error removing /private/tmp/tmpUdJYFW/dmg.Rfhwet/: [Errno 16] Resource busy: '/private/tmp/tmpUdJYFW/dmg.Rfhwet/'
Traceback (most recent call last):
  File "./AutoNBI.py", line 1284, in <module>
    main()
  File "./AutoNBI.py", line 1263, in main
    nbi.modify(nbimount, netinstallpath, nbishadow, mount)
  File "./AutoNBI.py", line 909, in modify
    os.mkdir(processdir)
OSError: [Errno 17] File exists: '/private/tmp/tmpUdJYFW/dmg.Rfhwet/'
```
jcuozzo in the [#autonbi](https://macadmins.slack.com/archives/autonbi/p1480545574000225) Slack channel recommended the change in this PR and it now works reliably in my workflow without needing to add the `--folder` option.