### PR TITLE
Add libcrypto for high-sierra

### DIFF
--- a/AutoNBI.py
+++ b/AutoNBI.py
@@ -809,7 +809,7 @@ class processNBI(object):
             # In High Sierra pretty much everything is in Core. New name. Same contents.
             # We also need to add libssl as it's no longer standard.
             payloads = { 'python': {'sourcepayloads': ['Core'],
-                                    'regex': '\"*Py*\" \"*py*\" \"*libssl*\" \"*libffi.dylib*\" \"*libexpat*\"'},
+                                    'regex': '\"*Py*\" \"*py*\" \"*libssl*\" \"*libcrypto*\" \"*libffi.dylib*\" \"*libexpat*\"'},
                          'ruby': {'sourcepayloads': ['Core'],
                                   'regex': '\"*ruby*\" \"*lib*ruby*\" \"*Ruby.framework*\"  \"*libssl*\"'}
                        }


### PR DESCRIPTION
Fixes issues with `diskutil` and python/hashlib when building with a high sierra source